### PR TITLE
Add Openserum DEX to DEX listings

### DIFF
--- a/content/built-on-serum/_index.en.md
+++ b/content/built-on-serum/_index.en.md
@@ -29,6 +29,7 @@ Most of these projects are not open source. Use at your own risk.
 - [Ourord DEX](https://dex.ourord.com)
 - [TradeOnSerum DEX](https://www.tradeonserum.com/)
 - [YMAX DEX](https://ymax.finance/)
+- [Openserum](https://openserum.ch/)
 
 ### Mobile DEX GUIs
 

--- a/content/dex-list/_index.en.md
+++ b/content/dex-list/_index.en.md
@@ -56,6 +56,8 @@ There are many teams who are hosting GUIs on Serum DEX markets; some have signif
 
 - Doce Finance Trade: [https://dex.doce.finance/](https://dex.doce.finance/)
 
+- Openserum DEX: [https://openserum.ch/dex](https://openserum.ch/dex/)
+
 ### Mobile
 
 - Coin98: [https://coin98.app](https://coin98.app)

--- a/content/dex-list/_index.zh.md
+++ b/content/dex-list/_index.zh.md
@@ -47,6 +47,8 @@ weight: 3
 
 - Serum Trade: [https://serum.trade](https://serum.trade)
 
+- Openserum DEX: [https://openserum.ch/dex](https://openserum.ch/dex/)
+
 ### 移动端
 
 - Coin98: [https://coin98.app](https://coin98.app)


### PR DESCRIPTION
* Adds Openserum.ch Serum DEX front-end to existing lists on the "Built on Serum" and "DEX List" page.